### PR TITLE
Add UrbanPolygonDataset and update scripts

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -271,7 +271,7 @@ def main(network_pkl, port, data_dir, init_dir, outdir, seeds, max_batch_size, w
     if dist.get_rank() != 0:
         torch.distributed.barrier()
 
-    dataset_kwargs = dnnlib.EasyDict(class_name='src.datasets.polygon_datasets.S3DPolygonDataset', 
+    dataset_kwargs = dnnlib.EasyDict(class_name='src.datasets.urban_polygon_dataset.UrbanPolygonDataset',
                     data_dir=data_dir, init_dir=init_dir, split='test', rand_aug=False)
 
     network_kwargs = dnnlib.EasyDict()

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -1,21 +1,21 @@
 # Multiple GPUs
 CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 --master_port 12345 \
-    train.py --outdir=training-runs/s3d/denoise \
+    train.py --outdir=training-runs/urban/denoise \
     --exp_name_suffix="samples_15M" \
-    --data_dir=data/processed_s3d --train_mode=denoise --init_dir=init_results/npy_roomformer_s3d_256 \
+    --data_dir=data/urban --train_mode=denoise --init_dir=init_results/urban \
     --sig_data 1.0 \
     --p_mean=-0.5  --p_std=1.5 \
     --lr=2e-4 --batch=104 --batch-gpu=26  \
     --tick=5 --snap=100 --dump=1000 \
     --workers=8 --duration=15 \
-    --guide_ckpt="training-runs/s3d_pretrained_ckpts/guide/polydiffuse-s3d-guide/network-snapshot.pth" \
+    --guide_ckpt="training-runs/urban_pretrained_ckpts/guide/polydiffuse-urban-guide/network-snapshot.pth" \
 
 
 # Single GPU debugging
-#CUDA_VISIBLE_DEVICES=1 python train.py --outdir=training-runs/s3d/denoise \
-#   --data_dir=data/processed_s3d --init_dir=init_results/npy_roomformer_s3d_256 \
+#CUDA_VISIBLE_DEVICES=1 python train.py --outdir=training-runs/urban/denoise \
+#   --data_dir=data/urban --init_dir=init_results/urban \
 #   --train_mode=denoise \
 #   --batch=8  --lr=2e-4 --tick=1 --snap=5 \
 #   --p_mean=-0.5 --p_std=1.5 --sig_data=1.0 \
-#   --guide_ckpt="training-runs/s3d_pretrained_ckpts/guide/polydiffuse-s3d-guide/network-snapshot.pth" \
+#   --guide_ckpt="training-runs/urban_pretrained_ckpts/guide/polydiffuse-urban-guide/network-snapshot.pth" \
 #   --exp_name_suffix="debug_single_gpu"

--- a/src/datasets/urban_polygon_dataset.py
+++ b/src/datasets/urban_polygon_dataset.py
@@ -1,0 +1,118 @@
+import os
+import numpy as np
+from torch.utils.data import Dataset
+from shapely.geometry import Polygon
+
+class UrbanPolygonDataset(Dataset):
+    """Dataset loading building polygons and land-lot bounding boxes."""
+
+    def __init__(self, data_dir, split, init_dir=None, rand_aug=False,
+                 max_polygon=50, max_vert=50, mask_prob=0.0):
+        super().__init__()
+        self.data_dir = data_dir
+        self.split = split
+        self.init_dir = init_dir
+        self.rand_aug = rand_aug
+        self.max_polygon = max_polygon
+        self.max_vert = max_vert
+        self.mask_prob = mask_prob
+
+        split_dir = os.path.join(data_dir, split)
+        self.files = sorted([
+            os.path.join(split_dir, f) for f in os.listdir(split_dir)
+            if f.endswith('.npz') or f.endswith('.npy')
+        ])
+
+    def __len__(self):
+        return len(self.files)
+
+    def __getitem__(self, idx):
+        sample_path = self.files[idx]
+        sample = np.load(sample_path, allow_pickle=True)
+        polygons = sample['polygons']
+        bboxes = sample['bboxes']
+        polygons = [np.array(p) for p in polygons]
+
+        if len(polygons) > self.max_polygon:
+            new_idx = np.random.randint(0, len(self.files))
+            return self.__getitem__(new_idx)
+
+        polygon_verts = np.zeros([self.max_polygon, self.max_vert, 2], dtype=np.float32)
+        verts_indicator = np.zeros([self.max_polygon, self.max_vert], dtype=np.float32)
+        gt_num_verts = np.zeros([self.max_polygon], dtype=np.int32)
+
+        polygon_mask = self.generate_polygon_mask(polygons)
+
+        for poly_idx, poly_item in enumerate(polygons):
+            processed_polygon = self.preprocess_polygon(poly_item)
+            num_vert = len(processed_polygon)
+            gt_num_verts[poly_idx] = num_vert
+            polygon_verts[poly_idx, :num_vert, :] = processed_polygon
+            verts_indicator[poly_idx, :num_vert] = 1
+
+        polygon_verts = polygon_verts / 127.5 - 1
+        verts_indicator_tensor = verts_indicator[..., None] * 2 - 1
+        polygon_verts = np.concatenate([polygon_verts, verts_indicator_tensor], axis=-1)
+
+        mimic_proposal_results = self.get_polygons_bbox_init(polygon_verts, bboxes, gt_num_verts)
+
+        data = {
+            'image': np.zeros([3, 256, 256], dtype=np.float32),
+            'polygon_verts': polygon_verts,
+            'verts_indicator': verts_indicator,
+            'num_polygon': len(polygons),
+            'num_verts': gt_num_verts,
+            'polygon_mask': polygon_mask,
+            'mimic_proposal_results': mimic_proposal_results,
+        }
+        return data
+
+    def generate_polygon_mask(self, polygons):
+        mask = np.zeros([self.max_polygon], dtype=np.int32)
+        if 'train' in self.split and self.mask_prob > 0:
+            num_polys = len(polygons)
+            rand_mask = (np.random.random([num_polys]) < self.mask_prob)
+            mask[:num_polys] = rand_mask.astype(np.int32)
+        return mask
+
+    def preprocess_polygon(self, polygon_verts):
+        sort_inds = np.lexsort((polygon_verts[:, 1], polygon_verts[:, 0]))
+        start_idx = sort_inds[0]
+        sorted_verts = np.concatenate([polygon_verts[start_idx:], polygon_verts[:start_idx]], axis=0)
+        winding = self.compute_winding(sorted_verts)
+        if winding < 0:
+            sorted_verts = np.concatenate([sorted_verts[0:1], sorted_verts[-1:0:-1]], axis=0)
+        return sorted_verts
+
+    @staticmethod
+    def compute_winding(polygon_verts):
+        winding_sum = 0
+        for idx, vert in enumerate(polygon_verts):
+            next_idx = idx + 1 if idx < len(polygon_verts) - 1 else 0
+            next_vert = polygon_verts[next_idx]
+            winding_sum += (next_vert[0] - vert[0]) * (next_vert[1] + vert[1])
+        return winding_sum
+
+    def get_polygons_bbox_init(self, polygons, bboxes, gt_num_verts):
+        polygons_init = polygons.copy()
+        for poly_idx in range(len(bboxes)):
+            num_vert = int(gt_num_verts[poly_idx])
+            if num_vert == 0:
+                continue
+            x1, y1, x2, y2 = bboxes[poly_idx]
+            rect = np.array([[x1, y1], [x2, y1], [x2, y2], [x1, y2]], dtype=np.float32)
+            if num_vert <= 4:
+                coords = rect[:num_vert]
+            else:
+                t_vals = np.linspace(0, 4, num_vert, endpoint=False)
+                coords = []
+                for t in t_vals:
+                    seg = int(t)
+                    frac = t - seg
+                    v0 = rect[seg % 4]
+                    v1 = rect[(seg + 1) % 4]
+                    coords.append(v0 * (1 - frac) + v1 * frac)
+                coords = np.stack(coords, axis=0)
+            coords = coords / 127.5 - 1
+            polygons_init[poly_idx, :num_vert, :2] = coords
+        return polygons_init

--- a/train.py
+++ b/train.py
@@ -34,6 +34,7 @@ warnings.filterwarnings('ignore', 'Grad strides do not match bucket view strides
 @click.option('--dropout',       help='Dropout probability', metavar='FLOAT',                       type=click.FloatRange(min=0, max=1), default=0.13, show_default=True)
 @click.option('--augment',       help='Augment probability', metavar='FLOAT',                       type=click.FloatRange(min=0, max=1), default=0.12, show_default=True)
 @click.option('--xflip',         help='Enable dataset x-flips', metavar='BOOL',                     type=bool, default=False, show_default=True)
+@click.option('--poly_mask_prob', help='Probability of masking polygons during training', metavar='FLOAT', type=click.FloatRange(min=0, max=1), default=0.0, show_default=True)
 @click.option('--sig_data',      help='sigma of the data, used in precond and loss', metavar='FLOAT', type=click.FloatRange(min=0, min_open=True), default=1.0, show_default=True)
 @click.option('--p_mean',      help='mena of log sigma for training', metavar='FLOAT', type=float, default=-0.7, show_default=True)
 @click.option('--p_std',      help='std of log sigma for training', metavar='FLOAT', type=float, default=2.1, show_default=True)
@@ -66,8 +67,9 @@ def main(**kwargs):
 
     # Initialize config dict.
     c = dnnlib.EasyDict()
-    c.dataset_kwargs = dnnlib.EasyDict(class_name='src.datasets.polygon_datasets.S3DPolygonDataset', 
-                    data_dir=opts.data_dir, init_dir=opts.init_dir, split='train', rand_aug=True)
+    c.dataset_kwargs = dnnlib.EasyDict(class_name='src.datasets.urban_polygon_dataset.UrbanPolygonDataset',
+                    data_dir=opts.data_dir, init_dir=opts.init_dir, split='train', rand_aug=True,
+                    mask_prob=opts.poly_mask_prob)
     c.data_loader_kwargs = dnnlib.EasyDict(pin_memory=True, num_workers=opts.workers, prefetch_factor=2)
     c.network_kwargs = dnnlib.EasyDict()
     c.loss_kwargs = dnnlib.EasyDict()
@@ -76,7 +78,7 @@ def main(**kwargs):
     # Validate dataset options.
     try:
         dataset_obj = dnnlib.util.construct_class_by_name(**c.dataset_kwargs)
-        dataset_name = 's3d'
+        dataset_name = 'urban'
         del dataset_obj # conserve memory
     except IOError as err:
         raise click.ClickException(f'--data: {err}')


### PR DESCRIPTION
## Summary
- implement `UrbanPolygonDataset` to load bounding boxes and polygons
- switch training and generation to use `UrbanPolygonDataset`
- allow masking probability during training
- update training script paths for the new dataset

## Testing
- `python3 - <<'PY'
from src.datasets.urban_polygon_dataset import UrbanPolygonDataset

ds = UrbanPolygonDataset(data_dir='data/urban', split='train')
item = ds[0]
print('keys', item.keys())
print('polygon_verts shape', item['polygon_verts'].shape)
print('proposal shape', item['mimic_proposal_results'].shape)
PY`
- `python3 train.py --help` *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_6875b67f734c83268481638420cd9fcd